### PR TITLE
[skip-on-collision] Won't overwrite files with the same name

### DIFF
--- a/ctrlc.d
+++ b/ctrlc.d
@@ -1,5 +1,4 @@
 import std.stdio : writeln, File;
-import std.string : strip;
 import std.path : buildPath;
 import std.file : getcwd;
 import std.getopt;
@@ -21,17 +20,15 @@ void main(string[] args)
     }
 
     auto clipboard = Clipboard(getClipboardPath());
-    auto logger = Logger(verbosity);
-    auto pending = buildPath(getcwd, args[1]);
+
+    immutable logger = Logger(verbosity);
+    immutable pending = buildPath(getcwd, args[1]);
     logger("Copying " ~ pending);
 
-    foreach(char[] entry; clipboard.list())
+    if(clipboard.has(pending))
     {
-        if(entry.strip == pending.strip)
-        {
-            writeln(pending, " is already queued for copying");
-            return;
-        }
+        writeln(pending, " is already queued for copying");
+        return;
     }
     clipboard.append(pending);
 }

--- a/ctrlp.d
+++ b/ctrlp.d
@@ -19,7 +19,7 @@ void main(string[] args)
 
     if(result.helpWanted)
     {
-        defaultGetoptPrinter("Pastard - ctrlc", result.options);
+        defaultGetoptPrinter("Pastard - ctrlp", result.options);
         return;
     }
 
@@ -37,20 +37,26 @@ void main(string[] args)
         return;
     }
 
-    scope(success)
-    {
-        clipboard.reset();
-    }
-
+    char[][] remaining;
     foreach(char[] entry; clipboard.list())
     {
         logger("Copying " ~ entry ~ " to " ~ getcwd);
+        immutable localFile = buildPath(getcwd, entry.baseName);
+        if(localFile.exists)
+        {
+            remaining ~= entry.dup;
+            writeln(entry.baseName, " already exists in this directory.");
+            continue;
+        }
 
         if(!entry.exists)
         {
             writeln(entry, " no longer exists.");
             continue;
         }
-        copy(entry, buildPath(getcwd, entry.baseName));
+        copy(entry, localFile);
     }
+
+    clipboard.reset();
+    clipboard.append(remaining);
 }

--- a/tests/copy_paste_collision.sh
+++ b/tests/copy_paste_collision.sh
@@ -1,0 +1,53 @@
+alias ctrlc=$(pwd)/../ctrlc
+alias ctrlp=$(pwd)/../ctrlp
+
+echo Running $0
+
+#setup
+ctrlp --reset
+if [ -f tmp ]; then
+    rm -rf tmp
+fi
+
+if [ -f a ]; then
+    rm a
+fi
+
+#test
+mkdir tmp
+touch tmp/a
+echo foo > a
+echo bar > b
+echo baz > c
+ctrlc a
+ctrlc b
+ctrlc c
+cd tmp
+content=$(ctrlp)
+expected="a already exists in this directory."
+echo $content
+
+if [ "$content" = "$expected" ]
+then
+    echo 1/2 OK
+else
+    echo 1/2 Failed : "$expected" != "$content"
+fi
+
+cd ..
+
+content=$(ctrlp --list)
+expected="$(pwd)/a"
+if [ "$content" = "$expected" ]
+then
+    echo 2/2 OK
+else
+    echo 2/2 Failed : "$expected" != "$content"
+fi
+
+#cleanup
+rm -rf tmp
+rm a
+rm b
+rm c
+ctrlp --reset

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,4 @@
-for f in $(ls); do
+for f in $(ls *.sh); do
     if [ $f != $0 ]; then
         sh $f
     fi

--- a/utils.d
+++ b/utils.d
@@ -1,7 +1,10 @@
 import std.traits : isSomeString;
+import std.range : ElementType, isInputRange;
 import std.array : array;
 import std.file : exists;
+import std.string : strip;
 import std.stdio : File, lines;
+import std.algorithm : each;
 
 struct Clipboard
 {
@@ -11,6 +14,18 @@ struct Clipboard
     {
         this.path = path;
         init();
+    }
+
+    bool has(string path) const
+    {
+        foreach(char[] entry; list())
+        {
+            if(entry.strip == path.strip)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     void init()
@@ -35,6 +50,12 @@ struct Clipboard
     {
         File(path, "a").writeln(pending);
     }
+
+    void append(StringRange)(StringRange pending) if(isInputRange!StringRange && isSomeString!(ElementType!StringRange))
+    {
+        auto fh = File(path, "a");
+        pending.each!(p => fh.writeln(p));
+    }
 }
 
 struct Logger
@@ -46,7 +67,7 @@ struct Logger
         this.verbosity = verbosity;
     }
 
-    void log(T)(lazy T dg) if(isSomeString!T)
+    void log(T)(lazy T dg) const if(isSomeString!T)
     {
         if(verbosity)
         {
@@ -54,7 +75,7 @@ struct Logger
         }
     }
 
-    void opCall(T)(lazy T dg) if(isSomeString!T)
+    void opCall(T)(lazy T dg) const if(isSomeString!T)
     {
         log(dg);
     }


### PR DESCRIPTION
If a folder contains files with the same name as those of the clipboard,
the files in the working directory won't be overwritten.

They will however be kept in the clipboard and a notification will be
displayed to warn the user about this.